### PR TITLE
Fix hypergraph name typo

### DIFF
--- a/css/ob_hypergraph.css
+++ b/css/ob_hypergraph.css
@@ -59,7 +59,7 @@
     margin-right: 10px;
 }
 
-#hypergrah_name, #hypergrah_underline, #hypergrah_underline2 {
+#hypergraph_name, #hypergraph_underline, #hypergraph_underline2 {
     font-weight: bold;
     color: #2574a6;
     text-align: center; /* Center align the text */

--- a/openbexi_hypergraph.html
+++ b/openbexi_hypergraph.html
@@ -7,15 +7,15 @@
 <body>
 <div id="container"></div>
 <div id="menu">
-    <div id="hypergrah_name">
+    <div id="hypergraph_name">
     </div>
-    <div id="hypergrah_underline"> __________________________
+    <div id="hypergraph_underline"> __________________________
     </div>
     <div id="gridOption">
         <input type="checkbox" id="showGrid" checked>
         <label for="showGrid">Show Grid</label>
     </div>
-    <div id="hypergrah_underline2"> __________________________
+    <div id="hypergraph_underline2"> __________________________
     </div>
     <div id="saveOption">
         <img src="./icons/ob_save.png" id="saveIcon" title="Save Model" alt=""/>

--- a/src/ob_hypergraph.js
+++ b/src/ob_hypergraph.js
@@ -51,7 +51,7 @@ function OB_HYPERGRAPH(models) {
         // Event listener for the save icon click
         document.getElementById('saveIcon').addEventListener('click', () => this.saveHyperGraph(vertices, edges));
         document.getElementById('loadIcon').addEventListener('click', () => this.loadHyperGraph(this.models));
-        document.getElementById('hypergrah_name').innerText = this.hypergraph_name;
+        document.getElementById('hypergraph_name').innerText = this.hypergraph_name;
         document.addEventListener('DOMContentLoaded', () => {
             const selectionContainer = document.getElementById('menu'); // Assuming 'menu' is where we want to insert the dropdown
             let dropdownExists = false;
@@ -222,7 +222,7 @@ function OB_HYPERGRAPH(models) {
         return this.loadJSON(hypergraph_file)
             .then(data => {
                 if (data && data.hypergraph) {
-                    document.getElementById('hypergrah_name').innerText = data.hypergraph.name;
+                    document.getElementById('hypergraph_name').innerText = data.hypergraph.name;
                     return data.hypergraph;
                 } else {
                     throw new Error('Invalid JSON structure');


### PR DESCRIPTION
## Summary
- rename mis-typed `hypergrah_*` IDs to `hypergraph_*`
- update CSS and JS references

## Testing
- `grep -R "hypergrah" -n`

------
https://chatgpt.com/codex/tasks/task_e_685efe8426ac83319589d9b201c07a87