### PR TITLE
Fix module import paths

### DIFF
--- a/openbexi_hypergraph.html
+++ b/openbexi_hypergraph.html
@@ -32,7 +32,6 @@
     {
         "imports": {
             "three": "./node_modules/three/build/three.module.min.js",
-            "drag_controls": "./node_modules/three/examples/jsm/controls/DragControls.js",
             "three-spritetext": "./node_modules/three-spritetext/dist/three-spritetext.mjs"
         }
     }

--- a/src/ob_hypergraph.js
+++ b/src/ob_hypergraph.js
@@ -1,8 +1,8 @@
 import * as THREE from 'three';
-import {OrbitControls} from '/three/examples/jsm/controls/OrbitControls.js';
-import {DragControls} from '/three/examples/jsm/controls/DragControls.js';
-import {FontLoader} from "/three/examples/jsm/loaders/FontLoader.js";
-import {TextGeometry} from '/three/examples/jsm/geometries/TextGeometry.js';
+import { OrbitControls } from './node_modules/three/examples/jsm/controls/OrbitControls.js';
+import { DragControls } from './node_modules/three/examples/jsm/controls/DragControls.js';
+import { FontLoader } from './node_modules/three/examples/jsm/loaders/FontLoader.js';
+import { TextGeometry } from './node_modules/three/examples/jsm/geometries/TextGeometry.js';
 import {Grid} from './ob_grid.js';
 import {LocalStorage} from './ob_local_storage.js';
 import SpriteText from "three-spritetext";


### PR DESCRIPTION
## Summary
- fix relative import paths in `ob_hypergraph.js`
- simplify import map in example HTML

## Testing
- `npm test` *(fails: Missing script)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657fb004e08331ba5ba9c09f26f554